### PR TITLE
Broken changes are fixed

### DIFF
--- a/Gurux.DLMS.Client.Example.Net/GXDLMSReader.cs
+++ b/Gurux.DLMS.Client.Example.Net/GXDLMSReader.cs
@@ -637,7 +637,7 @@ namespace Gurux.DLMS.Reader
                 {
                     Console.WriteLine("-------- Reading " + it.GetType().Name + " " + it.Name + " " + it.Description);
                 }
-                foreach (int pos in (it as IGXDLMSBase).GetAttributeIndexToRead())
+                foreach (int pos in (it as IGXDLMSBase).GetAttributeIndexToRead(true))
                 {
                     try
                     {

--- a/Gurux.DLMS.Client.Example.Net/GXDLMSReader.cs
+++ b/Gurux.DLMS.Client.Example.Net/GXDLMSReader.cs
@@ -263,7 +263,7 @@ namespace Gurux.DLMS.Reader
             bool bFound = false;
             foreach (GXDLMSImageActivateInfo it in target.ImageActivateInfo)
             {
-                if (it.Identification == identification)
+                if (ASCIIEncoding.ASCII.GetString(it.Identification) == identification)
                 {
                     bFound = true;
                     break;

--- a/Gurux.DLMS.XmlClient/GXDLMSReader.cs
+++ b/Gurux.DLMS.XmlClient/GXDLMSReader.cs
@@ -476,7 +476,7 @@ namespace Gurux.DLMS.Reader
                 {
                     Console.WriteLine("-------- Reading " + it.GetType().Name + " " + it.Name + " " + it.Description);
                 }
-                foreach (int pos in (it as IGXDLMSBase).GetAttributeIndexToRead())
+                foreach (int pos in (it as IGXDLMSBase).GetAttributeIndexToRead(true))
                 {
                     try
                     {


### PR DESCRIPTION
**Gurux.DLMS.Client.Example.Net** and **Gurux.DLMS.XmlClient** are broken in Version 8.5.1803.0401 [[887661f](https://github.com/Gurux/Gurux.DLMS.Net/commit/887661f2a63bb4d85c65700aad84e0bca85900f1)] Version 8.5.1803.0701 [[768ad0a](https://github.com/Gurux/Gurux.DLMS.Net/commit/768ad0aff66b86b535842c30a2d4adabf45dca72)]

Both broken changes are fixed.