### PR TITLE
Dedicated ciphering fixes

### DIFF
--- a/Development/GXDLMSTranslator.cs
+++ b/Development/GXDLMSTranslator.cs
@@ -1245,6 +1245,7 @@ namespace Gurux.DLMS
                     xml.AppendLine(cmd, "Value", GXCommon.ToHex(value.Data, false, value.Position, value.Size - value.Position));
                     break;
                 case (byte)Command.GeneralGloCiphering:
+                case (byte)Command.GeneralDedCiphering:
                     if (settings.Cipher != null && Comments)
                     {
                         int len2 = xml.GetXmlLength();
@@ -1294,7 +1295,7 @@ namespace Gurux.DLMS
                     len = GXCommon.GetObjectCount(value);
                     tmp = new byte[len];
                     value.Get(tmp);
-                    xml.AppendStartTag(Command.GeneralGloCiphering);
+                    xml.AppendStartTag((Command)cmd);
                     xml.AppendLine(TranslatorTags.SystemTitle, null,
                             GXCommon.ToHex(tmp, false, 0, len));
                     len = GXCommon.GetObjectCount(value);
@@ -1302,7 +1303,7 @@ namespace Gurux.DLMS
                     value.Get(tmp);
                     xml.AppendLine(TranslatorTags.CipheredService, null,
                             GXCommon.ToHex(tmp, false, 0, len));
-                    xml.AppendEndTag(Command.GeneralGloCiphering);
+                    xml.AppendEndTag((Command)cmd);
                     break;
                 case (byte)Command.ConfirmedServiceError:
                     data.Xml = xml;

--- a/Development/Secure/GXCiphering.cs
+++ b/Development/Secure/GXCiphering.cs
@@ -132,6 +132,15 @@ namespace Gurux.DLMS.Secure
         }
 
         /// <summary>
+        /// DedicatedInvocation counter.
+        /// </summary>
+        public UInt32 DedicatedInvocationCounter
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The SystemTitle is a 8 bytes (64 bit) value that identifies a partner of the communication.
         /// First 3 bytes contains the three letters manufacturer ID.
         /// The remainder of the system title holds for example a serial number.
@@ -191,7 +200,7 @@ namespace Gurux.DLMS.Secure
             }
         }
         /// <summary>
-        /// Authentication Key is 16 bytes value.
+        /// Dedicated Key is 16 bytes value.
         /// </summary>
         public byte[] DedicatedKey
         {
@@ -206,6 +215,7 @@ namespace Gurux.DLMS.Secure
                     throw new ArgumentOutOfRangeException("Invalid DedicatedKey Key.");
                 }
                 dedicatedKey = value;
+                DedicatedInvocationCounter = 0;
             }
         }
         
@@ -233,6 +243,7 @@ namespace Gurux.DLMS.Secure
         {
             Security = Gurux.DLMS.Enums.Security.None;
             InvocationCounter = 0;
+            DedicatedInvocationCounter = 0;
         }
 
         bool GXICipher.IsCiphered()

--- a/Development/Secure/GXDLMSChippering.cs
+++ b/Development/Secure/GXDLMSChippering.cs
@@ -173,6 +173,7 @@ namespace Gurux.DLMS.Secure
             switch (cmd)
             {
                 case Command.GeneralGloCiphering:
+                case Command.GeneralDedCiphering:
                     len = GXCommon.GetObjectCount(data);
                     if (len != 0)
                     {

--- a/Development/Secure/GXICipher.cs
+++ b/Development/Secure/GXICipher.cs
@@ -101,5 +101,14 @@ namespace Gurux.DLMS.Secure
             get;
             set;
         }
+
+        /// <summary>
+        /// Frame counter for Dedicated key. Invocation counter.
+        /// </summary>
+        UInt32 DedicatedInvocationCounter
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
- Added ability to translate GeneralDedCiphering to XML. Currently it showed as "Data".
- Add ability to decrypt GeneralDecCiphering PDUs.
- Added a new invocation counter (frame counter) for the dedicated key, as stated in the DLMS Green Book. This is reset to 0 every time the dedicated key is set.