### PR TITLE
Update GXDLMSProfileGeneric.cs

### DIFF
--- a/Development/Objects/GXDLMSProfileGeneric.cs
+++ b/Development/Objects/GXDLMSProfileGeneric.cs
@@ -933,7 +933,7 @@ namespace Gurux.DLMS.Objects
             if (e.Value != null)
             {
                 int index2;
-                DateTimeOffset lastDate = DateTime.MinValue.ToLocalTime();
+                Nullable<DateTimeOffset> lastDate = null;
                 foreach (object tmp in (IEnumerable<object>)e.Value)
                 {
                     List<object> row = new List<object>();
@@ -978,14 +978,14 @@ namespace Gurux.DLMS.Objects
                             }
                             else if (type == DataType.DateTime && row[pos] == null && CapturePeriod != 0)
                             {
-                                if (lastDate == DateTime.MinValue && Buffer.Count != 0)
+                                if (!lastDate.HasValue && Buffer.Count != 0)
                                 {
                                     lastDate = ((GXDateTime)Buffer[Buffer.Count - 1].GetValue(pos)).Value;
                                 }
-                                if (lastDate != DateTime.MinValue)
+                                if (lastDate.HasValue)
                                 {
-                                    lastDate = lastDate.AddSeconds(CapturePeriod);
-                                    row[pos] = new GXDateTime(lastDate);
+                                    lastDate = lastDate.Value.AddSeconds(CapturePeriod);
+                                    row[pos] = new GXDateTime(lastDate.Value);
                                 }
                             }
                             else if (type == DataType.DateTime)


### PR DESCRIPTION
The datetime.MinValue causes a problem when a GMT + offset is used. An exception is thrown when comparing the lastDate to the MinValue. Since the code only tries to determine if there is a valid value in the lastDate variable, I changed it to use a Nullable. That way, no comparison is needed with the MinValue and no exception is thrown.
This is the exception btw: The UTC time represented when the offset is applied must be between year 0 and 10,000. Parameter name: offset