### PR TITLE
HandleAarqRequest with ProposedMaxPduSize 0 fails

### DIFF
--- a/Development/GXDLMSServer.cs
+++ b/Development/GXDLMSServer.cs
@@ -1904,6 +1904,11 @@ namespace Gurux.DLMS
                         error.SetUInt8(ServiceError.Initiate);
                         error.SetUInt8(Initiate.IncompatibleConformance);
                     }
+                    //If PDU is 0 we set to max allowed.
+                    else if (Settings.MaxPduSize == 0)
+                    {
+                        Settings.MaxPduSize = 65535;
+                    }
                     //If PDU is too low.
                     else if (Settings.MaxPduSize < 64)
                     {


### PR DESCRIPTION
On AARQ if ProposedMaxPduSize is 0 we set to max allowed 65535