### PR TITLE
Bug Fix for LN Ciphering mismatch

### DIFF
--- a/Development/Internal/GXAPDU.cs
+++ b/Development/Internal/GXAPDU.cs
@@ -1099,7 +1099,7 @@ namespace Gurux.DLMS.Internal
             int len;
             byte tag;
             AssociationResult resultComponent = AssociationResult.Accepted;
-            object ret = 0;
+            object ret = AssociationResult.Accepted;
             string msg;
             ApplicationContextName name;
             while (buff.Position < buff.Size)
@@ -1112,7 +1112,7 @@ namespace Gurux.DLMS.Internal
                         {
                             if (settings.IsServer)
                             {
-                                return name;
+                                continue;
                             }
                             switch (name)
                             {


### PR DESCRIPTION
**Fix: Server rejects LogicalNameWithCiphering context incorrectly**

Problem
DLMS servers with ciphering enabled reject client connections requesting LogicalNameWithCiphering context, responding with "Application context name not supported" even when properly configured.

Root Cause
GXAPDU.ParsePDU2() unconditionally returns the parsed ApplicationContextName for servers, which is then treated as a rejection error:
```
if (settings.IsServer)
{
    return name;  // ❌ Always rejects
}
```

After Fix: Impact
Enables ciphered connections (HLS auth, GMAC, etc.) on DLMS servers.
File: Development/GXAPDU.cs (method ParsePDU2)